### PR TITLE
Remove Lombok dependency from backend build

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -40,11 +40,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## Summary
- remove the Lombok dependency from the backend Maven POM so it is no longer on the annotation processor path

## Testing
- `mvn clean compile` *(fails: unable to download parent POM due to HTTP 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d9384821088324b7624c1ead84bd3e