### PR TITLE
Update Kafka stack to use published Zookeeper image

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 1. `docker compose -f docker-compose.kafka.yml up -d`
 2. Kafka 브로커는 `localhost:9092`에서 수신하며 토픽은 필요 시 자동 생성됩니다.
 3. Kafka UI는 `http://localhost:8082`에서 접속할 수 있고 `post-events` 토픽의 메시지를 실시간으로 확인할 수 있습니다.
-   - 구성은 `bitnami/zookeeper:3.9.2` 이미지를 사용하도록 업데이트되었습니다.
+   - 구성은 `bitnami/zookeeper:3.9.1` 이미지를 사용하도록 업데이트되었습니다.
 
 종료 시 `docker compose -f docker-compose.kafka.yml down`을 사용하세요.
 

--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   zookeeper:
-    image: bitnami/zookeeper:3.9.2
+    image: bitnami/zookeeper:3.9.1
     container_name: simplebbs-zookeeper
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes


### PR DESCRIPTION
## Summary
- align the Kafka Compose stack to use the published bitnami/zookeeper:3.9.1 tag
- mirror the updated Zookeeper image tag in the Kafka stack documentation

## Testing
- not run (infrastructure not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e26a5c89188324ad44ca3c90e084f5