### PR TITLE
Refine post event publisher callback

### DIFF
--- a/backend/src/main/java/com/example/simplebbs/post/event/PostEventPublisher.java
+++ b/backend/src/main/java/com/example/simplebbs/post/event/PostEventPublisher.java
@@ -30,12 +30,17 @@ public class PostEventPublisher {
      */
     public void publish(PostEvent event) {
         kafkaTemplate.send(topic, event.postId().toString(), event)
-                .addCallback(result -> {
+                .whenComplete((result, throwable) -> {
+                    if (throwable != null) {
+                        log.error("Failed to publish post event: {}", event, throwable);
+                        return;
+                    }
+
                     if (result != null && log.isDebugEnabled()) {
                         log.debug("Published post event to topic {} partition {} offset {}", topic,
                                 result.getRecordMetadata().partition(),
                                 result.getRecordMetadata().offset());
                     }
-                }, throwable -> log.error("Failed to publish post event: {}", event, throwable));
+                });
     }
 }


### PR DESCRIPTION
## Summary
- switch the post event publisher to use whenComplete for Kafka send callbacks
- log success at debug level and failures at error level within the completion handler

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e26ffb80508324bc2ab343047de053