### PR TITLE
Remove redundant Kafka value deserializer configuration

### DIFF
--- a/stats-service/src/main/java/com/example/poststats/config/KafkaConsumerConfig.java
+++ b/stats-service/src/main/java/com/example/poststats/config/KafkaConsumerConfig.java
@@ -26,7 +26,6 @@ public class KafkaConsumerConfig {
     public ConsumerFactory<String, PostEvent> postEventConsumerFactory() {
         Map<String, Object> props = kafkaProperties.buildConsumerProperties(null);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
 
         JsonDeserializer<PostEvent> jsonDeserializer = new JsonDeserializer<>(PostEvent.class);
         jsonDeserializer.addTrustedPackages("*");


### PR DESCRIPTION
## Summary
- remove the redundant value deserializer property so that the custom JsonDeserializer is the only one used

## Testing
- `mvn -f stats-service/pom.xml clean package` *(fails: unable to download spring-boot-starter-parent due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e275c3ee2c832489c88ed6dee86b78