### PR TITLE
Remove redundant JsonDeserializer trusted packages property

### DIFF
--- a/stats-service/src/main/resources/application.properties
+++ b/stats-service/src/main/resources/application.properties
@@ -5,5 +5,4 @@ spring.kafka.consumer.group-id=post-statistics-service
 spring.kafka.consumer.auto-offset-reset=earliest
 spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
 spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer
-spring.kafka.consumer.properties.spring.json.trusted.packages=*
 app.kafka.post-topic=post-events


### PR DESCRIPTION
## Summary
- remove the JsonDeserializer trusted packages consumer property from application.properties to avoid conflicting configuration

## Testing
- ./mvnw spring-boot:run *(fails: file not found in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e2771d1ff88324a5be4e20ce6f516a